### PR TITLE
Allow zsh completion to be autoloaded by compinit

### DIFF
--- a/cmd/minikube/cmd/completion.go
+++ b/cmd/minikube/cmd/completion.go
@@ -107,6 +107,8 @@ func GenerateBashCompletion(w io.Writer, cmd *cobra.Command) error {
 
 func GenerateZshCompletion(out io.Writer, cmd *cobra.Command) error {
 	zsh_initialization := `
+#compdef minikube
+
 __minikube_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand


### PR DESCRIPTION
This will allow minikube zsh autocompletion to work with compinit, same as [kubectl](https://github.com/kubernetes/kubernetes/pull/50561) does.